### PR TITLE
Move to opponents as player instances

### DIFF
--- a/src/axelrod_dojo/__init__.py
+++ b/src/axelrod_dojo/__init__.py
@@ -1,3 +1,8 @@
 from .version import __version__
 from .archetypes.fsm import FSMParams
-from .utils import prepare_objective, Population, load_params, Params, score_for
+from .utils import (prepare_objective,
+                    Population,
+                    load_params,
+                    Params,
+                    score_for,
+                    PlayerInfo)

--- a/src/axelrod_dojo/utils.py
+++ b/src/axelrod_dojo/utils.py
@@ -1,6 +1,6 @@
 from functools import partial
 from itertools import repeat
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from operator import itemgetter
 from random import randrange
 from statistics import mean, pstdev
@@ -168,6 +168,8 @@ class Population(object):
                  bottleneck=None, opponents=None, processes=1, weights=None):
         self.params_class = params_class
         self.bottleneck = bottleneck
+        if processes == 0:
+            processes = cpu_count()
         self.pool = Pool(processes=processes)
         self.outputer = Outputer(output_filename, mode='a')
         self.size = size

--- a/src/axelrod_dojo/utils.py
+++ b/src/axelrod_dojo/utils.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from functools import partial
 from itertools import repeat
 from multiprocessing import Pool, cpu_count
@@ -137,9 +138,10 @@ class Params(object):
     def crossover(self, other):
         pass
 
+PlayerInfo = namedtuple('PlayerInfo', ['strategy', 'init_kwargs'])
 
-def score_params(params, objective, opponents,
-                 opponent_init_kwargs=None,
+def score_params(params, objective,
+                 opponents_information,
                  weights=None):
     """
     Return the overall mean score of a Params instance.
@@ -147,12 +149,9 @@ def score_params(params, objective, opponents,
     scores_for_all_opponents = []
     player = params.player()
 
-    if opponent_init_kwargs is None:
-        opponent_init_kwargs = [{} for _ in opponents]
-
-    for opponent_class, init_kwargs in zip(opponents, opponent_init_kwargs):
+    for strategy, init_kwargs in opponents_information:
         player.reset()
-        opponent = opponent_class(**init_kwargs)
+        opponent = strategy(**init_kwargs)
         scores_for_this_opponent = objective(player, opponent)
         mean_vs_opponent = mean(scores_for_this_opponent)
         scores_for_all_opponents.append(mean_vs_opponent)
@@ -179,11 +178,11 @@ class Population(object):
         else:
             self.bottleneck = bottleneck
         if opponents is None:
-            self.opponents = axl.short_run_time_strategies
-            self.opponent_init_kwargs = None
+            self.opponents_information = [
+                    PlayerInfo(s, {}) for s in axl.short_run_time_strategies]
         else:
-            self.opponents = [p.__class__ for p in opponents]
-            self.opponent_init_kwargs = [p.init_kwargs for p in opponents]
+            self.opponents_information = [
+                    PlayerInfo(p.__class__, p.init_kwargs) for p in opponents]
         self.generation = 0
         self.params_args = params_args
         self.population = [params_class(*params_args) for _ in range(self.size)]
@@ -193,8 +192,7 @@ class Population(object):
         starmap_params = zip(
             self.population,
             repeat(self.objective),
-            repeat(self.opponents),
-            repeat(self.opponent_init_kwargs),
+            repeat(self.opponents_information),
             repeat(self.weights))
         results = self.pool.starmap(score_params, starmap_params)
         return results

--- a/tests/integration/test_fsm.py
+++ b/tests/integration/test_fsm.py
@@ -17,7 +17,7 @@ class TestFSMPopulation(unittest.TestCase):
         repetitions = 5
         num_states = 2
         mutation_rate = .1
-        opponents = axl.demo_strategies
+        opponents = [s() for s in axl.demo_strategies]
         size = 10
 
         objective = dojo.prepare_objective(name=name,
@@ -68,7 +68,7 @@ class TestFSMPopulation(unittest.TestCase):
         repetitions = 5
         num_states = 2
         mutation_rate = .1
-        opponents = axl.demo_strategies
+        opponents = [s() for s in axl.demo_strategies]
         size = 10
 
         objective = dojo.prepare_objective(name=name,

--- a/tests/integration/test_fsm.py
+++ b/tests/integration/test_fsm.py
@@ -112,3 +112,38 @@ class TestFSMPopulation(unittest.TestCase):
                 self.assertIsInstance(parameters, dojo.FSMParams)
 
             self.assertEqual(best[0].__repr__(), best_params)
+
+    def test_score_with_particular_players(self):
+        """
+        These are players that are known to be difficult to pickle
+        """
+        name = "score"
+        turns = 10
+        noise = 0
+        repetitions = 5
+        num_states = 2
+        mutation_rate = .1
+        opponents = [axl.ThueMorse(),
+                     axl.MetaHunter(),
+                     axl.BackStabber(),
+                     axl.Alexei()]
+        size = 10
+
+        objective = dojo.prepare_objective(name=name,
+                                           turns=turns,
+                                           noise=noise,
+                                           repetitions=repetitions)
+
+        population = dojo.Population(params_class=dojo.FSMParams,
+                                     params_args=(num_states, mutation_rate),
+                                     size=size,
+                                     objective=objective,
+                                     output_filename=self.temporary_file.name,
+                                     opponents=opponents,
+                                     bottleneck=2,
+                                     processes=0)
+
+        generations = 4
+        axl.seed(0)
+        population.run(generations)
+        self.assertEqual(population.generation, 4)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -193,6 +193,29 @@ class TestScoreParams(unittest.TestCase):
         expected_score = 2.0949
         self.assertEqual(score, expected_score)
 
+    def test_with_init_kwargs(self):
+        axl.seed(0)
+        opponents = [axl.Random]
+        opponent_init_kwargs = [{"p": 0}]  # Creating a defector
+        objective = utils.prepare_objective()
+        params = DummyParams()
+        score = utils.score_params(params,
+                                   objective=objective,
+                                   opponent_init_kwargs=opponent_init_kwargs,
+                                   opponents=opponents)
+        expected_score = 0
+        self.assertEqual(score, expected_score)
+
+        opponent_init_kwargs = [{"p": 1}]  # Creating a cooperator
+        objective = utils.prepare_objective()
+        params = DummyParams()
+        score = utils.score_params(params,
+                                   objective=objective,
+                                   opponent_init_kwargs=opponent_init_kwargs,
+                                   opponents=opponents)
+        expected_score = 3.0
+        self.assertEqual(score, expected_score)
+
     def test_score_with_weights(self):
         axl.seed(0)
         opponents = axl.demo_strategies

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -180,50 +180,48 @@ class DummyParams(utils.Params):
     def player(self):
         return axl.Cooperator()
 
-
 class TestScoreParams(unittest.TestCase):
     def test_score(self):
         axl.seed(0)
-        opponents = axl.demo_strategies
+        opponents_information = [utils.PlayerInfo(s, {})
+                                 for s in axl.demo_strategies]
         objective = utils.prepare_objective()
         params = DummyParams()
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponents=opponents)
+                                   opponents_information=opponents_information)
         expected_score = 2.0949
         self.assertEqual(score, expected_score)
 
     def test_with_init_kwargs(self):
         axl.seed(0)
-        opponents = [axl.Random]
-        opponent_init_kwargs = [{"p": 0}]  # Creating a defector
+        opponents_information = [utils.PlayerInfo(axl.Random, {"p": 0})]
         objective = utils.prepare_objective()
         params = DummyParams()
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponent_init_kwargs=opponent_init_kwargs,
-                                   opponents=opponents)
+                                   opponents_information=opponents_information)
         expected_score = 0
         self.assertEqual(score, expected_score)
 
-        opponent_init_kwargs = [{"p": 1}]  # Creating a cooperator
+        opponents_information = [utils.PlayerInfo(axl.Random, {"p": 1})]
         objective = utils.prepare_objective()
         params = DummyParams()
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponent_init_kwargs=opponent_init_kwargs,
-                                   opponents=opponents)
+                                   opponents_information=opponents_information)
         expected_score = 3.0
         self.assertEqual(score, expected_score)
 
     def test_score_with_weights(self):
         axl.seed(0)
-        opponents = axl.demo_strategies
+        opponents_information = [utils.PlayerInfo(s, {})
+                                 for s in axl.demo_strategies]
         objective = utils.prepare_objective()
         params = DummyParams()
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponents=opponents,
+                                   opponents_information=opponents_information,
                                    # All weight on Coop
                                    weights=[1, 0, 0, 0, 0])
         expected_score = 3
@@ -231,7 +229,7 @@ class TestScoreParams(unittest.TestCase):
 
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponents=opponents,
+                                   opponents_information=opponents_information,
                                    # Shared weight between Coop and Def
                                    weights=[2, 2, 0, 0, 0])
         expected_score = 1.5
@@ -239,7 +237,7 @@ class TestScoreParams(unittest.TestCase):
 
         score = utils.score_params(params,
                                    objective=objective,
-                                   opponents=opponents,
+                                   opponents_information=opponents_information,
                                    # Shared weight between Coop and Def
                                    weights=[2, -.5, 0, 0, 0])
         expected_score = 4.0


### PR DESCRIPTION
I've changed things so we just pass players to the `Population` class. That class in it's init obtains the player classes and the init_kwargs.

I've also added a test with a few players that have caused pickling hurdles in the past.

I've tested locally and this works fine with the axelrod_fortran strategies.